### PR TITLE
If the search prop is not provided, don't add it to the query params

### DIFF
--- a/src/components/GoodreadsBookshelf.jsx
+++ b/src/components/GoodreadsBookshelf.jsx
@@ -20,7 +20,13 @@ export default (props) => {
 		url.searchParams.set("shelf", props.shelf || "read");
 		url.searchParams.set("sort", props.sort || "date_read");
 		url.searchParams.set("order", props.order || "d");
-		url.searchParams.set("search[query]", props.search || "");
+
+		// If this is provided as an empty string, you can get wildly different
+		// results for currently-reading
+		if (props.search) {
+			url.searchParams.set("search[query]", props.search);
+		}
+
 		url.searchParams.set("v", 2);
 		return url;
 	};


### PR DESCRIPTION
I love this package! I just upgraded to the latest version and it's throwing of my ability to show my currently-reading shelf. I determined that if you give an empty search param, Goodreads will disregard the shelf you are selecting and search your whole account. Below are the URLs generated for before and after upgrading, note that the results differ quite a bit.

* Before: https://www.goodreads.com/review/list/29665939?key=TSX2BO7dC8AMZstT2H6MBg&per_page=10&shelf=currently-reading&sort=date_read&v=2
* After: https://www.goodreads.com/review/list/29665939?key=TSX2BO7dC8AMZstT2H6MBg&per_page=10&shelf=currently-reading&sort=date_read&order=d&search%5Bquery%5D=&v=2