### PR TITLE
fix: remove role grid and replace with ul li

### DIFF
--- a/src/components/BookList.module.css
+++ b/src/components/BookList.module.css
@@ -2,4 +2,6 @@
   display: grid;
   justify-content: space-around;
   align-items: top;
+  list-style: none;
+  padding: 0;
 }

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -23,11 +23,15 @@ const shelfStyle = (options?: Props): CSSProperties => {
 
 const BookList: FunctionComponent<{ books: BookType[]; options?: Props }> = ({ books, options }) => {
   return (
-    <div className={`rgs-shelf ${styles.shelf}`} style={shelfStyle(options)} role="grid">
+    <ul className={`rgs-shelf ${styles.shelf}`} style={shelfStyle(options)}>
       {books.map((book) => {
-        return <Book key={book.id} book={book} options={options} />;
+        return (
+          <li key={book.id}>
+            <Book book={book} options={options} />
+          </li>
+        );
       })}
-    </div>
+    </ul>
   );
 };
 


### PR DESCRIPTION
## Description

Fix accessibility issue where `role=grid` was used but needed to have more manual properties added to the children.

In this particular situation, the use of `<ul>/<li>`provides a more accessible and semantically meaningful way to represent a grid-like structure. It leverages the built-in list semantics, making it easier for assistive technologies and users to understand and interact with the grid.

## Screenshot

(From [axe DevTools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) v4.57.3)

![image](https://github.com/kylekarpack/react-goodreads-shelf/assets/237229/f9411dfe-9006-4b92-8fba-a3291046e9bb)
